### PR TITLE
Update doc_development.tex

### DIFF
--- a/developer/doc_development/doc_development.tex
+++ b/developer/doc_development/doc_development.tex
@@ -253,7 +253,7 @@ but the \texttt{auto\_} part is a Sphinx-gallery artifact. Its source file is:
     \begin{itemize}
         \item \texttt{:class:`\textasciitilde openturns.ClassName`} to link to the API doc of a class.
         \item \texttt{:meth:`\textasciitilde openturns.ClassName.method`} to link to the API doc of a class method.
-        \item \texttt{:ref:`\_theory\_page`} to link to a Theory doc page using its RST label.
+        \item \texttt{:ref:`theory\_page`} to link to a Theory doc page using its RST label.
         \item \texttt{:doc:`/auto\_category/subcategory/plot\_xxx`} (no \texttt{.py}) to link to another example.
     \end{itemize}
     \item Python scripts should be properly


### PR DESCRIPTION
To make a link to a theory page, the leading underscore must be removed:

![image](https://github.com/openturns/presentation/assets/31351465/c531b6ce-be4c-4b0f-93df-af8bc3953ebb)

