### PR TITLE
Correct Uncecomp2025 URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,4 +155,4 @@ OpenTURNS Presentations
   - `OpenTURNS and Persalys Overview <https://github.com/openturns/openturns.github.io/blob/master/presentation/master/bepu-2024-slides-OpenTURNS.pdf>`_
   - `Bayesian inference using MCMC in OpenTURNS <https://github.com/openturns/openturns.github.io/blob/master/presentation/master/bepu-2024-slides_OpenTURNS_MetropolisHastings.pdf>`_
 
-- `Uncecomp 2025 <https://github.com/openturns/openturns.github.io/blob/master/presentation/master/uncecomp_2025_slides_OpenTURNS.pdf>`_
+- `Uncecomp 2025 <https://github.com/openturns/openturns.github.io/blob/master/presentation/master/uncecomp-2025-slides-OpenTURNS.pdf>`_


### PR DESCRIPTION
@jschueller A mistake in the Uncecomp 2025 URL is corrected.